### PR TITLE
Fix FinishReason enum serialization in metadata storage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "test": [
             "@php vendor/bin/pest --parallel"
         ],
+        "format": "@php vendor/bin/pint",
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
         "build": "@php vendor/bin/testbench workbench:build --ansi",

--- a/src/Concerns/InteractsWithPrism.php
+++ b/src/Concerns/InteractsWithPrism.php
@@ -98,9 +98,7 @@ trait InteractsWithPrism
 
         // Extract finish reason
         if (isset($response->finishReason)) {
-            $metadata['finish_reason'] = is_object($response->finishReason) && method_exists($response->finishReason, 'value')
-                ? $response->finishReason->value
-                : $response->finishReason;
+            $metadata['finish_reason'] = $response->finishReason->name;
         }
 
         // Extract steps for multi-step responses

--- a/src/Support/PrismStream.php
+++ b/src/Support/PrismStream.php
@@ -96,9 +96,7 @@ class PrismStream
         }
 
         if (isset($response->finishReason)) {
-            $metadata['finish_reason'] = is_object($response->finishReason) && method_exists($response->finishReason, 'value')
-                ? $response->finishReason->value
-                : $response->finishReason;
+            $metadata['finish_reason'] = $response->finishReason->name;
         }
 
         return $metadata;

--- a/tests/Feature/ConversationPrismMethodsTest.php
+++ b/tests/Feature/ConversationPrismMethodsTest.php
@@ -133,7 +133,7 @@ it('adds prism response as assistant message', function () {
             'tokens' => 100,
             'prompt_tokens' => 50,
             'completion_tokens' => 50,
-            'finish_reason' => 'Stop',
+            'finish_reason' => FinishReason::Stop->name,
             'custom' => 'metadata',
         ]);
 });

--- a/tests/Feature/ConversationPrismMethodsTest.php
+++ b/tests/Feature/ConversationPrismMethodsTest.php
@@ -14,6 +14,7 @@ use ElliottLawson\ConversePrism\Models\Conversation;
 use ElliottLawson\ConversePrism\Models\Message;
 use ElliottLawson\ConversePrism\Support\PrismStream;
 use ElliottLawson\ConversePrism\Tests\Models\TestUser;
+use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
@@ -121,7 +122,7 @@ it('adds prism response as assistant message', function () {
             'promptTokens' => 50,
             'completionTokens' => 50,
         ],
-        'finishReason' => 'stop',
+        'finishReason' => FinishReason::Stop,
     ];
 
     $message = $this->conversation->addPrismResponse($response, ['custom' => 'metadata']);
@@ -132,7 +133,7 @@ it('adds prism response as assistant message', function () {
             'tokens' => 100,
             'prompt_tokens' => 50,
             'completion_tokens' => 50,
-            'finish_reason' => 'stop',
+            'finish_reason' => 'Stop',
             'custom' => 'metadata',
         ]);
 });

--- a/tests/Feature/PrismResponseHandlingTest.php
+++ b/tests/Feature/PrismResponseHandlingTest.php
@@ -13,8 +13,8 @@
  */
 
 use ElliottLawson\ConversePrism\Models\Conversation;
-use ElliottLawson\ConversePrism\Models\Message;
 use ElliottLawson\ConversePrism\Tests\Models\TestUser;
+use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\ValueObjects\Messages\AssistantMessage;
 use Prism\Prism\ValueObjects\Messages\SystemMessage;
 use Prism\Prism\ValueObjects\Messages\ToolResultMessage;
@@ -46,7 +46,7 @@ it('handles a complete Prism text response with all metadata', function () {
     {
         public $text = 'This is the assistant response';
 
-        public $finishReason = 'stop';
+        public $finishReason = FinishReason::Stop;
 
         public $usage;
 
@@ -76,7 +76,7 @@ it('handles a complete Prism text response with all metadata', function () {
             'tokens' => 40,
             'prompt_tokens' => 25,
             'completion_tokens' => 15,
-            'finish_reason' => 'stop',
+            'finish_reason' => 'Stop',
             'model' => 'claude-3-5-sonnet-20241022',
             'provider_request_id' => 'resp_123',
         ]);
@@ -178,7 +178,7 @@ it('handles streaming responses with proper chunk management', function () {
     {
         public $text = 'The weather in Paris is cloudy.';
 
-        public $finishReason = 'stop';
+        public $finishReason = FinishReason::Stop;
 
         public $usage;
 
@@ -205,7 +205,7 @@ it('handles streaming responses with proper chunk management', function () {
             'tokens' => 28,
             'prompt_tokens' => 20,
             'completion_tokens' => 8,
-            'finish_reason' => 'stop',
+            'finish_reason' => FinishReason::Stop->name,
         ])
         ->and($message->metadata)->toHaveKey('stream_duration_ms');
 });

--- a/tests/Feature/PrismResponseHandlingTest.php
+++ b/tests/Feature/PrismResponseHandlingTest.php
@@ -76,7 +76,7 @@ it('handles a complete Prism text response with all metadata', function () {
             'tokens' => 40,
             'prompt_tokens' => 25,
             'completion_tokens' => 15,
-            'finish_reason' => 'Stop',
+            'finish_reason' => FinishReason::Stop->name,
             'model' => 'claude-3-5-sonnet-20241022',
             'provider_request_id' => 'resp_123',
         ]);


### PR DESCRIPTION
## Summary
- Fix FinishReason enum serialization bug in metadata storage
- Replace enum->value access with enum->name for pure enums
- Update tests to use actual enum objects instead of string mocks

## Problem
The Prism package's `FinishReason` enum is a pure enum without backing values. The existing code tried to access a non-existent `value` property, causing JSON serialization errors when storing metadata.

## Solution
- Use `enum->name` instead of `enum->value` for proper serialization
- Fixed both `InteractsWithPrism` trait and `PrismStream` class
- Updated tests to properly simulate real Prism responses

## Test Plan
- [x] All existing tests pass
- [x] Tests now use actual FinishReason enum objects
- [x] Verified proper serialization of enum names to metadata