### PR TITLE
Fix composer package versioning issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "elliottlawson/converse-prism",
     "description": "Seamless integration between Laravel Converse and Prism PHP for AI conversations",
-    "version": "0.1.0",
     "keywords": ["laravel", "ai", "conversations", "prism", "llm", "openai", "anthropic"],
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
## Summary
- Remove hardcoded version from composer.json to fix Git tag recognition

## Problem
The package had `"version": "0.1.0"` hardcoded in composer.json, causing Composer to reject newer Git tags (v0.1.1, v0.1.2) with the error:
```
Skipped tag v0.1.2, tag (0.1.2.0) does not match version (0.1.0.0) in composer.json
```

## Solution
Remove the hardcoded version field from composer.json. For packages, versions should be determined by Git tags, not hardcoded in the file.

## Test Plan
- [x] Verified composer.json syntax is valid
- [x] After merge, existing tags v0.1.1 and v0.1.2 should be properly recognized by Composer