### PR TITLE
Fix incorrect Prism response metadata property access

### DIFF
--- a/src/Concerns/InteractsWithPrism.php
+++ b/src/Concerns/InteractsWithPrism.php
@@ -91,9 +91,9 @@ trait InteractsWithPrism
         }
 
         // Extract response metadata
-        if (isset($response->response)) {
-            $metadata['model'] = $response->response['model'] ?? null;
-            $metadata['provider_request_id'] = $response->response['id'] ?? null;
+        if (isset($response->meta)) {
+            $metadata['model'] = $response->meta->model ?? null;
+            $metadata['provider_request_id'] = $response->meta->id ?? null;
         }
 
         // Extract finish reason

--- a/src/Support/PrismStream.php
+++ b/src/Support/PrismStream.php
@@ -90,9 +90,9 @@ class PrismStream
             $metadata['completion_tokens'] = $response->usage->completionTokens ?? null;
         }
 
-        if (isset($response->response)) {
-            $metadata['model'] = $response->response['model'] ?? null;
-            $metadata['provider_request_id'] = $response->response['id'] ?? null;
+        if (isset($response->meta)) {
+            $metadata['model'] = $response->meta->model ?? null;
+            $metadata['provider_request_id'] = $response->meta->id ?? null;
         }
 
         if (isset($response->finishReason)) {


### PR DESCRIPTION
## Summary
- Fix bug where model and provider request ID metadata was not being extracted from Prism responses
- Update tests to use actual Prism value objects instead of mock structures

## Problem
The code was incorrectly trying to access `$response->response['model']` and `$response->response['id']`, but the actual Prism response objects store this information in `$response->meta->model` and `$response->meta->id`.

**Root cause:** The original code was written based on mock objects rather than the actual Prism response class structure.

**Impact:** 
- Model information was not being stored in conversation metadata
- Provider request IDs were not being captured for debugging/tracking
- No runtime errors due to `isset()` checks, but valuable metadata was missing

## Solution
- Change property access from `$response->response` to `$response->meta`
- Access properties directly (`meta->model`, `meta->id`) instead of as array elements
- Fix both `InteractsWithPrism` trait and `PrismStream` class
- Update tests to use real Prism `Usage` and `Meta` value objects

## Test Plan
- [x] All existing tests pass
- [x] Tests now properly simulate real Prism response structure
- [x] Verified model and provider request ID are now captured in metadata
- [x] Code follows actual Prism library structure and conventions