### PR TITLE
Fix critical token tracking and null safety issues

### DIFF
--- a/src/Concerns/InteractsWithPrism.php
+++ b/src/Concerns/InteractsWithPrism.php
@@ -85,9 +85,11 @@ trait InteractsWithPrism
 
         // Extract usage data
         if (isset($response->usage)) {
-            $metadata['tokens'] = $response->usage->totalTokens ?? null;
-            $metadata['prompt_tokens'] = $response->usage->promptTokens ?? null;
-            $metadata['completion_tokens'] = $response->usage->completionTokens ?? null;
+            $promptTokens = $response->usage->promptTokens ?? 0;
+            $completionTokens = $response->usage->completionTokens ?? 0;
+            $metadata['tokens'] = $promptTokens + $completionTokens;
+            $metadata['prompt_tokens'] = $promptTokens ?: null;
+            $metadata['completion_tokens'] = $completionTokens ?: null;
         }
 
         // Extract response metadata
@@ -98,7 +100,7 @@ trait InteractsWithPrism
 
         // Extract finish reason
         if (isset($response->finishReason)) {
-            $metadata['finish_reason'] = $response->finishReason->name;
+            $metadata['finish_reason'] = $response->finishReason?->name;
         }
 
         // Extract steps for multi-step responses

--- a/src/Support/PrismStream.php
+++ b/src/Support/PrismStream.php
@@ -85,9 +85,11 @@ class PrismStream
         $metadata = [];
 
         if (isset($response->usage)) {
-            $metadata['tokens'] = $response->usage->totalTokens ?? null;
-            $metadata['prompt_tokens'] = $response->usage->promptTokens ?? null;
-            $metadata['completion_tokens'] = $response->usage->completionTokens ?? null;
+            $promptTokens = $response->usage->promptTokens ?? 0;
+            $completionTokens = $response->usage->completionTokens ?? 0;
+            $metadata['tokens'] = $promptTokens + $completionTokens;
+            $metadata['prompt_tokens'] = $promptTokens ?: null;
+            $metadata['completion_tokens'] = $completionTokens ?: null;
         }
 
         if (isset($response->meta)) {
@@ -96,7 +98,7 @@ class PrismStream
         }
 
         if (isset($response->finishReason)) {
-            $metadata['finish_reason'] = $response->finishReason->name;
+            $metadata['finish_reason'] = $response->finishReason?->name;
         }
 
         return $metadata;

--- a/tests/Feature/ConversationPrismMethodsTest.php
+++ b/tests/Feature/ConversationPrismMethodsTest.php
@@ -146,7 +146,7 @@ it('adds prism response as assistant message', function () {
     expect($message->role->value)->toBe('assistant')
         ->and($message->content)->toBe('This is the AI response')
         ->and($message->metadata)->toMatchArray([
-            'tokens' => null,  // totalTokens not available in Usage object
+            'tokens' => 100,  // calculated: 50 + 50
             'prompt_tokens' => 50,
             'completion_tokens' => 50,
             'finish_reason' => FinishReason::Stop->name,

--- a/tests/Feature/PrismResponseHandlingTest.php
+++ b/tests/Feature/PrismResponseHandlingTest.php
@@ -73,7 +73,7 @@ it('handles a complete Prism text response with all metadata', function () {
     expect($message->role->value)->toBe('assistant')
         ->and($message->content)->toBe('This is the assistant response')
         ->and($message->metadata)->toMatchArray([
-            'tokens' => null,  // totalTokens not available in Usage object
+            'tokens' => 40,  // calculated: 25 + 15
             'prompt_tokens' => 25,
             'completion_tokens' => 15,
             'finish_reason' => FinishReason::Stop->name,
@@ -154,7 +154,7 @@ it('handles Prism tool call responses correctly', function () {
         ->and($message->content)->toBeJson()
         ->and(json_decode($message->content, true))->toBe($prismResponse->toolCalls)
         ->and($message->metadata)->toMatchArray([
-            'tokens' => null,  // totalTokens not available in Usage object
+            'tokens' => 80,  // calculated: 50 + 30
             'prompt_tokens' => 50,
             'completion_tokens' => 30,
         ]);
@@ -194,7 +194,7 @@ it('handles streaming responses with proper chunk management', function () {
             'model' => 'gpt-4',
             'streamed' => true,
             'chunks' => 7,
-            'tokens' => null,  // totalTokens not available in Usage object
+            'tokens' => 28,  // calculated: 20 + 8
             'prompt_tokens' => 20,
             'completion_tokens' => 8,
             'finish_reason' => FinishReason::Stop->name,
@@ -252,7 +252,7 @@ it('handles multi-step Prism responses', function () {
     $message = $this->conversation->addPrismResponse($prismResponse);
 
     expect($message->metadata['steps'])->toBe(3)
-        ->and($message->metadata['tokens'])->toBe(null);  // totalTokens not available in Usage object
+        ->and($message->metadata['tokens'])->toBe(150);  // calculated: 100 + 50
 });
 
 it('correctly handles missing or null Prism response fields', function () {


### PR DESCRIPTION
## Summary
- Fix critical bug where totalTokens was never being captured (always null)
- Add null safety to prevent potential runtime errors
- Update tests to properly validate calculated token values

## Critical Issues Fixed

### 1. **totalTokens Property Access Bug**
**Problem:** Code was trying to access `$response->usage->totalTokens` but this property doesn't exist on Prism's `Usage` object.

**Evidence:**
- Prism's `Usage` class only has `promptTokens` and `completionTokens` properties
- All tests were expecting `'tokens' => null` because the property was never found
- Token usage tracking was completely broken

**Fix:** Calculate total tokens as `promptTokens + completionTokens`

### 2. **Missing Null Safety**
**Problem:** `$response->finishReason->name` could cause fatal errors if `finishReason` is null.

**Fix:** Added null safety operator: `$response->finishReason?->name`

## Impact

**Before:**
- Token usage was always `null` in metadata (broken tracking)
- Potential for fatal errors on null finish reasons
- Misleading test assertions hiding the real issues

**After:**
- Accurate token tracking: 25 + 15 = 40 tokens
- Safe null handling for finish reasons
- Tests now validate real calculated values

## Test Plan
- [x] All existing tests pass with correct token calculations
- [x] Verified token totals are properly calculated (40, 80, 28, 150, 100)
- [x] Confirmed null safety prevents runtime errors
- [x] Both `InteractsWithPrism` trait and `PrismStream` class fixed

## Files Changed
- `src/Concerns/InteractsWithPrism.php` - Fix token calculation and null safety
- `src/Support/PrismStream.php` - Fix token calculation and null safety  
- Test files - Update expectations to match correct calculated values