### PR TITLE
Fix: Require minimum converse version 0.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "elliottlawson/converse": "^0.1",
+        "elliottlawson/converse": "^0.1.3",
         "illuminate/support": "^11.0|^12.0"
     },
     "suggest": {


### PR DESCRIPTION
## Problem

The converse-prism package depends on fluent chaining methods that were introduced in elliottlawson/converse v0.1.3. Without specifying this minimum version requirement, users may experience errors when trying to use the fluent interface if they have an older version of converse installed.

## Solution

Update composer.json to require `elliottlawson/converse: ^0.1.3` instead of `^0.1`.

This ensures that composer will pull in at least version 0.1.3 of the converse package, which includes the necessary fluent chaining support for methods like:

```php
$conversation
    ->addSystemMessage('You are helpful')
    ->addUserMessage('Hello')
    ->toPrismText()
    ->using(Provider::Anthropic, 'claude-3-5-sonnet-latest')
    ->asText();
```

## Testing

- Verified that converse v0.1.3 is the version that includes fluent chaining support
- All tests pass with this version requirement
- No breaking changes - this only enforces the minimum compatible version