### PR TITLE
Add automatic response saving with toPrismTextWithSave()

### DIFF
--- a/src/Support/PrismRequestProxy.php
+++ b/src/Support/PrismRequestProxy.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ElliottLawson\ConversePrism\Support;
+
+use ElliottLawson\Converse\Models\Conversation;
+
+class PrismRequestProxy
+{
+    protected $pendingRequest;
+
+    protected $conversation;
+
+    protected $metadata;
+
+    public function __construct($pendingRequest, Conversation $conversation, array $metadata = [])
+    {
+        $this->pendingRequest = $pendingRequest;
+        $this->conversation = $conversation;
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * Proxy all method calls to the underlying PendingTextRequest
+     */
+    public function __call($method, $arguments)
+    {
+        $result = $this->pendingRequest->$method(...$arguments);
+
+        // If the method returns the pending request, return the proxy instead
+        if ($result === $this->pendingRequest) {
+            return $this;
+        }
+
+        // Special handling for asText() to save to conversation
+        if ($method === 'asText') {
+            $this->conversation->addPrismResponse($result, $this->metadata);
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a minimal, non-invasive way to automatically save Prism responses to conversations without breaking the fluent API chain.

## Problem

Currently, when using Prism with Converse, you need to:
1. Execute the Prism request and get the response
2. Manually call `addPrismResponse()` to save it to the conversation
3. This breaks the fluent chain and requires storing the conversation in a variable

## Solution

Added a `toPrismTextWithSave()` method that returns a transparent proxy. The proxy:
- Passes all method calls through to the underlying Prism request
- Intercepts only the `asText()` call to automatically save the response
- Returns the exact same response object Prism would return
- Maintains full compatibility with the Prism API

## Usage

**Before:**
```php
$conversation = $this->productRequirements->getConversations();
$response = $conversation
    ->toPrismText()
    ->using(Provider::Anthropic, config('prism.model'))
    ->withMaxTokens(8000)
    ->asText();
$conversation->addPrismResponse($response);
```

**After:**
```php
$response = $this->productRequirements->getConversations()
    ->toPrismTextWithSave()  // Only change needed
    ->using(Provider::Anthropic, config('prism.model'))
    ->withMaxTokens(8000)
    ->asText();
// Response is automatically saved and returned unchanged
```

## Key Benefits

- **Non-invasive**: Doesn't wrap or modify Prism functionality
- **Optional**: Original `toPrismText()` still works when you don't want auto-save
- **Transparent**: Returns the exact same response object
- **Minimal**: Just one new method and a simple proxy class
- **Metadata support**: Can pass optional metadata to be saved with the response

## Implementation Details

The implementation uses a proxy pattern (`PrismRequestProxy`) that:
1. Forwards all method calls to the underlying `PendingTextRequest`
2. Returns itself for chainable methods to maintain the proxy
3. Intercepts `asText()` to save the response before returning it
4. Uses PHP's `__call()` magic method for transparent forwarding