### PR TITLE
Update minimum Converse version to 0.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "elliottlawson/converse": "^0.1.3",
+        "elliottlawson/converse": "^0.2.0",
         "illuminate/support": "^11.0|^12.0"
     },
     "suggest": {


### PR DESCRIPTION
## Summary
Updates the minimum required version of elliottlawson/converse from ^0.1.3 to ^0.2.0

## Reason
Breaking changes were introduced in Converse 0.2.0 that require this package to update its minimum version requirement.

## Changes
- Updated composer.json to require `"elliottlawson/converse": "^0.2.0"`

## Impact
This is a breaking change for users of converse-prism who are still on Converse 0.1.x. They will need to upgrade to Converse 0.2.0 or higher.